### PR TITLE
Use same printer configuration as go fmt

### DIFF
--- a/lib/lib.go
+++ b/lib/lib.go
@@ -162,7 +162,8 @@ func BumpInFile(vtype VersionType, filename string) (*Version, error) {
 				if err != nil {
 					return nil, err
 				}
-				err = printer.Fprint(f, fset, parsedFile)
+				cfg := printer.Config{Mode: printer.UseSpaces | printer.TabIndent, Tabwidth: 8}
+				err = cfg.Fprint(f, fset, parsedFile)
 				if err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
Currently if you run bump_version on a file, you get tabs between the name
declarations and type declarations of a struct, for example:

```
type User struct{
\tName\t\tstring
}
```

The same file when run through `go fmt ./...` will use spaces between the name
and type declarations, like this:

```
type User struct{
\tName   string
}
```

Formats the go/printer command to match the default arguments used by go fmt.
I have no idea why these two aren't in sync already.
