### PR TITLE
Allow specifying a specific version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,14 @@
 install:
 	go install ./...
 
-test:
+lint:
+ifndef STATICCHECK
+	go get -u honnef.co/go/tools/cmd/staticcheck
+endif
+	go vet ./...
+	staticcheck ./...
+
+test: lint
 	go test -race ./... -timeout 1s
 
 release: install test

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 
@@ -13,36 +12,62 @@ import (
 const VERSION = "1.2"
 
 func usage() {
-	fmt.Fprintf(os.Stderr, "Usage: bump_version <major|minor|patch> <filename>\n")
+	fmt.Fprintf(os.Stderr, "Usage: bump_version [--version=<version>] [<major|minor|patch>] <filename>\n")
+	flag.PrintDefaults()
 }
 
 // runCommand execs the given command and exits if it fails.
 func runCommand(binary string, args ...string) {
 	out, err := exec.Command(binary, args...).CombinedOutput()
 	if err != nil {
-		log.Fatalf("Error when running command: %s.\nOutput was:\n%s", err.Error(), string(out))
+		fmt.Fprintf(os.Stderr, "Error when running command: %s.\nOutput was:\n%s", err.Error(), string(out))
+		os.Exit(2)
 	}
 }
+
+var vsn = flag.String("version", "", "Set this version in the file (don't increment whatever version is present)")
 
 func main() {
 	flag.Usage = usage
 	flag.Parse()
 	args := flag.Args()
-	if len(args) != 2 {
-		usage()
-		os.Exit(2)
-	}
-	versionTypeStr := args[0]
-	filename := args[1]
-
-	version, err := bump_version.BumpInFile(bump_version.VersionType(versionTypeStr), filename)
-	if err != nil {
-		log.Fatal(err)
+	var filename string
+	var version *bump_version.Version
+	if *vsn != "" {
+		// no "minor"
+		if len(args) != 1 {
+			flag.Usage()
+			return
+		}
+		var err error
+		version, err = bump_version.Parse(*vsn)
+		if err != nil {
+			os.Stderr.WriteString(err.Error())
+			os.Exit(2)
+		}
+		filename = args[0]
+		setErr := bump_version.SetInFile(version, filename)
+		if setErr != nil {
+			os.Stderr.WriteString(setErr.Error() + "\n")
+			os.Exit(2)
+		}
 	} else {
-		fmt.Fprintf(os.Stderr, "Bumped version to %s\n", version)
+		if len(args) != 2 {
+			flag.Usage()
+			return
+		}
+		versionTypeStr := args[0]
+		filename = args[1]
+
+		var err error
+		version, err = bump_version.BumpInFile(bump_version.VersionType(versionTypeStr), filename)
+		if err != nil {
+			os.Stderr.WriteString(err.Error() + "\n")
+			os.Exit(2)
+		}
 	}
 	runCommand("git", "add", filename)
 	runCommand("git", "commit", "-m", version.String())
 	runCommand("git", "tag", version.String(), "--annotate", "--message", version.String())
-	fmt.Fprintf(os.Stderr, "Added new commit and tagged version %s.\n", version)
+	os.Stdout.WriteString(version.String() + "\n")
 }


### PR DESCRIPTION
This works better with tools that want you to pass in the version
number, instead of automatically incrementing it based on what's in
the file. An example of this is in a Makefile where I want to do four
different things with the same version number - it's difficult to
get the version number from this program and then pass it all of the
places it's needed, it's easier to just pass it in and use everywhere.

Updates the successful output to be only the new version number and
a newline. Refactors the code to be more modular and adds a new
SetInFile method for setting a given version number in a file.